### PR TITLE
Lint CSS code with stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "homepage": "http://postcss.com/",
   "scripts": {
-    "lint": "eslint --ignore-path .gitignore .",
+    "lint": "eslint --ignore-path .gitignore . && stylelint web_modules/**/*.css",
     "start": "babel-node scripts/build --server --dev --open",
     "static": "babel-node scripts/build --static --production",
     "pretest": "npm run lint",
@@ -17,6 +17,9 @@
       "eslint-config-i-am-meticulous",
       "eslint-config-i-am-meticulous/react"
     ]
+  },
+  "stylelint": {
+    "extends": "stylelint-config-standard"
   },
   "devDependencies": {
     "autoprefixer": "^6.2.3",
@@ -54,6 +57,8 @@
     "redux-thunk": "^0.1.0",
     "statinamic": "^0.5.1",
     "style-loader": "^0.12.4",
+    "stylelint": "^3.2.2",
+    "stylelint-config-standard": "^0.2.0",
     "webpack": "^1.12.9",
     "whatwg-fetch": "^0.9.0"
   }

--- a/web_modules/Footer/index.css
+++ b/web_modules/Footer/index.css
@@ -1,3 +1,1 @@
-.footer {
-
-}
+.footer { /* placeholder */ }

--- a/web_modules/Header/index.css
+++ b/web_modules/Header/index.css
@@ -1,7 +1,3 @@
-.nav {
+.nav { /* placeholder */ }
 
-}
-
-.link {
-
-}
+.link { /* placeholder */ }

--- a/web_modules/Wrapper/index.css
+++ b/web_modules/Wrapper/index.css
@@ -1,4 +1,5 @@
 /* GLOBAL STYLES, OMG ! */
+
 :global h1,
 :global h2,
 :global h3 {
@@ -16,18 +17,18 @@
 :global .markdownIt-Anchor {
   position: absolute;
   left: -1.5rem;
-  opacity: .1;
-  transition: opacity .2s;
+  opacity: 0.1;
+  transition: opacity 0.2s;
 }
 
-  :global h1:hover .markdownIt-Anchor,
-  :global h2:hover .markdownIt-Anchor,
-  :global h3:hover .markdownIt-Anchor,
-  :global h4:hover .markdownIt-Anchor,
-  :global h5:hover .markdownIt-Anchor,
-  :global h6:hover .markdownIt-Anchor {
-    opacity: 1;
-  }
+:global h1:hover .markdownIt-Anchor,
+:global h2:hover .markdownIt-Anchor,
+:global h3:hover .markdownIt-Anchor,
+:global h4:hover .markdownIt-Anchor,
+:global h5:hover .markdownIt-Anchor,
+:global h6:hover .markdownIt-Anchor {
+  opacity: 1;
+}
 
 :global a,
 :global a:visited {
@@ -36,7 +37,7 @@
 }
 
 :global blockquote {
-  opacity: .6;
+  opacity: 0.6;
   margin: 2rem 0;
   padding-left: 1.5rem;
   border-left: 4px solid grey;
@@ -49,18 +50,18 @@
   font-weight: 400;
 
   color: color(#7340c4) l(-10%));
-  border: 1px solid #DDD;
+  border: 1px solid #ddd;
   border-radius: 0.3em;
-  background: color(#fafafa a(.6));
+  background: color(#fafafa a(0.6));
 }
 
 :global .hljs-comment {
-  opacity: .4;
+  opacity: 0.4;
 }
 
-  :global .hljs-comment:hover {
-    opacity: .6;
-  }
+:global .hljs-comment:hover {
+  opacity: 0.6;
+}
 
 :global .hljs-keyword {
   font-weight: bold;
@@ -74,7 +75,7 @@
   color: #7340c4;
 }
 
-/***/
+/* * */
 
 .wrapper {
   max-width: 50rem;


### PR DESCRIPTION
Ref: #51

Adds stylelint to the `npm run lint` run-script.

I put the config inside `package.json` to match the existing babel and eslint configs.

There were a handful of changes to the CSS to bring it inline with `stylelint-config-standard`, mainly consistent leading zeros and hex color case.